### PR TITLE
prevent trying to store images for DICOM with no pixel data elements

### DIFF
--- a/DICOMcloud/DICOMcloud/UncompressedPixelData.cs
+++ b/DICOMcloud/DICOMcloud/UncompressedPixelData.cs
@@ -23,8 +23,8 @@ namespace DICOMcloud
                 // pull uncompressed frame from source pixel data
                 Dataset = ds ;
             }
-            
-            PixelData = (Dataset.GetSingleValue<string>(DicomTag.Modality) != "SR") ? DicomPixelData.Create(Dataset) : null;
+
+            PixelData = DicomPixelData.Create(Dataset);
         }
 
         public fo.DicomDataset Dataset { get; private set; }

--- a/DICOMcloud/Media/Writers/JpegMediaWriter.cs
+++ b/DICOMcloud/Media/Writers/JpegMediaWriter.cs
@@ -8,6 +8,7 @@ using Dicom.Imaging;
 using Dicom.Imaging.Codec ;
 using DICOMcloud.IO;
 using System.IO;
+using Dicom;
 
 namespace DICOMcloud.Media
 {
@@ -33,6 +34,12 @@ namespace DICOMcloud.Media
             }
         }
 
+        public override bool CanUpload(DicomDataset ds, int frame)
+        {
+            var pixelDataItem = ds.GetDicomItem<DicomItem>(fo.DicomTag.PixelData);
+
+            return pixelDataItem != null;
+        }
 
         protected override fo.DicomDataset GetMediaDataset ( fo.DicomDataset data, DicomMediaProperties mediaInfo )
         {
@@ -48,12 +55,12 @@ namespace DICOMcloud.Media
         )
         {
             var frameIndex = frame - 1 ;
-            var dicomImage = (dicomObject.GetSingleValue<string>(fo.DicomTag.Modality) != "SR") ? new DicomImage(dicomObject, frameIndex) : null;
-            var bitmap = dicomImage?.RenderImage (frameIndex).AsSharedBitmap();
+            var dicomImage = new DicomImage(dicomObject, frameIndex);
+            var bitmap = dicomImage.RenderImage(frameIndex).AsSharedBitmap();
             var stream = new MemoryStream ( ) ;
-            
-            bitmap?.Save (stream, System.Drawing.Imaging.ImageFormat.Jpeg );
-            
+
+            bitmap.Save(stream, System.Drawing.Imaging.ImageFormat.Jpeg);
+
             stream.Position = 0 ;
 
             storeLocation.Upload ( stream, MediaType ) ;

--- a/DICOMcloud/Media/Writers/UncompressedMediaWriter.cs
+++ b/DICOMcloud/Media/Writers/UncompressedMediaWriter.cs
@@ -7,6 +7,7 @@ using fo = Dicom;
 using Dicom.Imaging;
 using DICOMcloud.IO;
 using Dicom.IO.Buffer;
+using Dicom;
 
 namespace DICOMcloud.Media
 {
@@ -32,10 +33,17 @@ namespace DICOMcloud.Media
             }
         }
 
+        public override bool CanUpload(DicomDataset ds, int frame)
+        {
+            var pixelDataItem = ds.GetDicomItem<DicomItem>(fo.DicomTag.PixelData);
+
+            return pixelDataItem != null;
+        }
+
         protected override void Upload ( fo.DicomDataset dicomDataset, int frame, IStorageLocation storeLocation, DicomMediaProperties mediaProperties)
         {
             var uncompressedData = new UncompressedPixelDataWrapper ( dicomDataset ) ;
-            var buffer           = uncompressedData.PixelData?.GetFrame ( frame - 1 ) ;
+            var buffer           = uncompressedData.PixelData.GetFrame(frame - 1);
             var  data            = new byte[0] ;
             
             


### PR DESCRIPTION
The approach is generic so any DICOM instance that doesn't have an image won't throw an error.